### PR TITLE
Add functionality to disable/re-enable buttons on click

### DIFF
--- a/lib/__init__.R
+++ b/lib/__init__.R
@@ -28,7 +28,8 @@ required_pkgs <- c(
   "mapview",
   "PostcodesioR",
   "leaflet", # to render the mapview
-  "lubridate"
+  "lubridate",
+  "withr"
 ) # Consider "tinytex" to generate pdf?
 
 for (pkg in required_pkgs) {

--- a/lib/disableReenableButton.R
+++ b/lib/disableReenableButton.R
@@ -1,0 +1,5 @@
+disableReenable <- function(name, func, ...) {
+    shinyjs::disable(name)
+    withr::defer(shinyjs::enable(name))
+    func(...)
+}

--- a/lib/ui/api.R
+++ b/lib/ui/api.R
@@ -248,9 +248,9 @@ apiServer <- function(input, output, session) {
 
   output$apiStatus <- renderAPIStatus(api)
 
-  observeEvent(input$connectAPI, connectAPIEvent(input, api))
+  observeEvent(input$connectAPI, disableReenable("connectAPI", connectAPIEvent, input, api))
 
-  observeEvent(input$disconnectAPI, disconnectAPIEvent(api))
+  observeEvent(input$disconnectAPI, disableReenable("disconnectAPI", disconnectAPIEvent, api))
 
   # Update the Load Data button
   observe({
@@ -258,7 +258,7 @@ apiServer <- function(input, output, session) {
     apiConnectedEvent(session, api)
   })
 
-  observeEvent(input$reloadData, reloadStudyEvent(input, output, session, api))
+  observeEvent(input$reloadData, disableReenable("reloadData", reloadStudyEvent, input, output, session, api))
 
   api
 }


### PR DESCRIPTION
This PR disables the connect and disconnect API and reloadData buttons whilst they are being processed to help prevent double loading.