### PR TITLE
Removed reference to recurrenceTab in app.R

### DIFF
--- a/app.R
+++ b/app.R
@@ -130,7 +130,6 @@ ui <- dashboardPage(
       tabItem("referralstatus",   referralStatusPlotTab()),
       tabItem("referralmaps",     referralMapTab()),
       tabItem("rxpathwaytab",     pathwayTab()),
-      tabItem("recurrencetab",    recurrenceTab()),
       tabItem("survivaltab",      survivalTab()),
       tabItem("audit-pathway",    auditTab()),
       tabItem("rxpathwaysummary", pathwaySummaryTab()),


### PR DESCRIPTION
Since the recurrence table has been removed, we need to remove its reference in the ui part of app.R

Fixes: `Error in recurrenceTab() : could not find function "recurrenceTab"`