### PR TITLE
Remove missing dtt fix

### DIFF
--- a/lib/plots/wait_time_dashboard_plot.R
+++ b/lib/plots/wait_time_dashboard_plot.R
@@ -118,7 +118,7 @@ processWaitTimesPerPeriod <- function(doneData, waitingData, start, end, range_b
         # RxDate is within the period
         filter(RxDate >= as.Date(range_start(period)) & RxDate < as.Date(range_end(period))) |>
         mutate(
-          DTTDateFixed = pmin(DTTDate, RxDate, na.rm = T),
+          DTTDateFixed = DTTDate,
         ) |>
         summariseRefToDTT() |>
         mutate(group = "By Ablation Date") |>
@@ -137,7 +137,7 @@ processWaitTimesPerPeriod <- function(doneData, waitingData, start, end, range_b
               )
           )) |>
         mutate(
-          DTTDateFixed = pmin(DTTDate, RxDate, na.rm = T),
+          DTTDateFixed = DTTDate,
         ) |>
         summariseRefToDTT() |>
         mutate(group = "By DTT Date") |>
@@ -155,7 +155,7 @@ processWaitTimesPerPeriod <- function(doneData, waitingData, start, end, range_b
               )
           )) |>
         mutate(
-          DTTDateFixed = pmin(as.Date(range_end(period)), DTTDate, RxDate, na.rm = T),
+          DTTDateFixed = pmin(as.Date(range_end(period)), DTTDate, na.rm = T),
         ) |>
         summariseRefToDTT() |>
         mutate(group = "Waiting") |>


### PR DESCRIPTION
Previously for the waiting list plots if there was a missing DTT date for a treated patient we would force the missing date to be the same as the RxDate.

This PR removes that fix and instead adds an embedded bar chart to show these.